### PR TITLE
update zip dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/yeka/zip"
+	"github.com/alexmullins/zip"
 	"io"
 	"io/ioutil"
 	"log"


### PR DESCRIPTION
As repo `https://github.com/keyas/zip` is no longer exists, we can use origin Repo `https://github.com/alexmullins/zip` instead